### PR TITLE
Support source-directories from elm.json

### DIFF
--- a/src/ElmFormat.hs
+++ b/src/ElmFormat.hs
@@ -183,7 +183,7 @@ format elmVersion (inputFile, inputText) =
     case parseModule (inputFile, inputText) of
         Right modu ->
             let
-                (transformed, info) = Transformer.transform modu
+                (transformed, info) = Transformer.transform modu inputFile
                 outputText = Render.render elmVersion transformed
             in
             Right $ Res inputFile info outputText


### PR DESCRIPTION
Connected to https://github.com/zwilias/elm-coverage/pull/28

This is very very crude, solves the problem in a wrong way, creates more problems just to band-aid them later, but it unblocked me in my usecase.

The solved problem:
**`elm-coverage` only reads `src/` directory for sources**

The solution:
**`elm-coverage` now reads the `elm.json` file for source directories and threads that filepath info throughout its execution**

It would be best to ditch this particular solution (it's really a hot pile of mess) and instead refactor the code to not assume some things (single source directory), but I'm offering this in case it helps anybody :)