### PR TITLE
cabal >= 1.25 and ghc 8.8 support

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,8 +1,14 @@
+{-# LANGUAGE CPP #-}
 import Distribution.Simple
+#if MIN_VERSION_Cabal(1,25,0)
+import Distribution.Simple.BuildPaths (autogenComponentModulesDir)
+#else
 import Distribution.Simple.BuildPaths (autogenModulesDir)
+#endif
 import Distribution.Simple.LocalBuildInfo (LocalBuildInfo)
 import Distribution.Simple.Setup (BuildFlags)
 import Distribution.PackageDescription (PackageDescription, emptyHookedBuildInfo)
+import Distribution.Simple.LocalBuildInfo (withLibLBI)
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath ((</>))
 import System.Process (readProcess)
@@ -10,13 +16,19 @@ import System.Process (readProcess)
 
 main = defaultMainWithHooks $ simpleUserHooks { buildHook = myBuildHook }
 
-
 myBuildHook :: PackageDescription -> LocalBuildInfo -> UserHooks -> BuildFlags -> IO ()
 myBuildHook packageDescription buildInfo userHooks buildFlags =
-    do
-        createDirectoryIfMissing True (autogenModulesDir buildInfo)
-        writeCustomFile (autogenModulesDir buildInfo </> "Build_elm_instrument.hs")
-        buildHook simpleUserHooks packageDescription buildInfo userHooks buildFlags
+#if MIN_VERSION_Cabal(1,25,0)
+  withLibLBI packageDescription buildInfo $ \_ libCfg -> do
+    createDirectoryIfMissing True (autogenComponentModulesDir buildInfo libCfg)
+    writeCustomFile (autogenComponentModulesDir buildInfo libCfg </> "Build_elm_instrument.hs")
+    buildHook simpleUserHooks packageDescription buildInfo userHooks buildFlags
+#else
+  do
+    createDirectoryIfMissing True (autogenModulesDir buildInfo)
+    writeCustomFile (autogenModulesDir buildInfo </> "Build_elm_instrument.hs")
+    buildHook simpleUserHooks packageDescription buildInfo userHooks buildFlags
+#endif
 
 
 writeCustomFile :: FilePath -> IO ()

--- a/markdown/Cheapskate/ParserCombinators.hs
+++ b/markdown/Cheapskate/ParserCombinators.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Cheapskate.ParserCombinators (
     Position(..)
   , Parser
@@ -37,6 +38,7 @@ import qualified Data.Text as T
 import Control.Monad
 import Control.Applicative
 import qualified Data.Set as Set
+import qualified Control.Monad.Fail as Fail
 
 data Position = Position { line :: Int, column :: Int }
      deriving (Ord, Eq)
@@ -107,9 +109,14 @@ instance Alternative Parser where
   {-# INLINE empty #-}
   {-# INLINE (<|>) #-}
 
+instance Fail.MonadFail Parser where
+  fail e = Parser $ \st -> Left $ ParseError (position st) e
+
 instance Monad Parser where
   return x = Parser $ \st -> Right (st, x)
-  fail e = Parser $ \st -> Left $ ParseError (position st) e
+#if !MIN_VERSION_base(4,13,0)
+  fail = Fail.fail
+#endif
   p >>= g = Parser $ \st ->
     case evalParser p st of
          Left e        -> Left e

--- a/src/ElmFormat/Execute.hs
+++ b/src/ElmFormat/Execute.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE Rank2Types #-}
 module ElmFormat.Execute (forHuman, forMachine, run) where
 
-{-| This module provides executors that can take streams of Operations and
+{- This module provides executors that can take streams of Operations and
 perform IO.
 -}
 


### PR DESCRIPTION
This PR addresses some future compatibility concerns without actually changing dependencies itself. My motivation is need to make this package compatible with newer versions of Cabal and GHC as part of packaging to nixpkgs.

Related PR in elm-format: https://github.com/avh4/elm-format/pull/640
Related issue: https://github.com/zwilias/elm-instrument/issues/2