### PR TITLE
Update optparse-applicative to 0.16

### DIFF
--- a/elm-instrument.cabal
+++ b/elm-instrument.cabal
@@ -132,7 +132,7 @@ library
         indents >= 0.3.3 && < 0.4,
         json >= 0.9.1 && < 0.10,
         mtl >= 2.2.1 && < 3,
-        optparse-applicative >= 0.14.2.0 && < 0.15,
+        optparse-applicative >= 0.16 && < 0.17,
         parsec >= 3.1.11 && < 4,
         process >= 1.4.2.0 && < 2,
         split >= 0.2.3.1 && < 0.3,

--- a/src/Flags.hs
+++ b/src/Flags.hs
@@ -26,7 +26,7 @@ usage :: String -> String -> String
 usage progName version =
     fst $
     Opt.renderFailure
-        (Opt.parserFailure preferences (parser version) Opt.ShowHelpText mempty)
+        (Opt.parserFailure preferences (parser version) (Opt.ShowHelpText Nothing) mempty)
         progName
 
 
@@ -47,7 +47,7 @@ showHelpText elmFormatVersion = Opt.Failure $
     Opt.parserFailure
         preferences
         (parser elmFormatVersion)
-        Opt.ShowHelpText
+        (Opt.ShowHelpText Nothing)
         mempty
 
 


### PR DESCRIPTION
This allows building elm-instrument on the upcoming NixOS 21.05.